### PR TITLE
add -a to grep

### DIFF
--- a/regress/regress.sh
+++ b/regress/regress.sh
@@ -11,7 +11,7 @@ testhttpcode() {
 	local code=
 
 	curl -sS -X "$verb" -i "$baseurl/$path" 2>/dev/null\
-	    | grep -v -e Date: -e Server: > "$tmp"
+	    | grep -a -v -e Date: -e Server: > "$tmp"
 	code=$(grep -a 'HTTP/1.1' "$tmp" | tail -n 1 | cut -d' ' -f 2)
 	if [ "$code" != "$desiredcode" ]; then
 		error=1
@@ -28,7 +28,7 @@ testhttpcodewithredirect() {
 	local code=
 
 	curl -sLS -X "$verb" -i "$baseurl/$path" 2>/dev/null\
-	    | grep -v -e Date: -e Server: > "$tmp"
+	    | grep -a -v -e Date: -e Server: > "$tmp"
 	code=$(grep -a HTTP "$tmp" | tail -n 1 | cut -d' ' -f 2)
 	if [ "$code" != "$desiredcode" ]; then
 		error=1


### PR DESCRIPTION
On my machine, I needed to add -a to grep for the curl lines. Otherwise output was 'Binary file matches'.